### PR TITLE
Apply autopep8 to pep format

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -44,10 +44,9 @@ def restricted(func):
         return func(bot, update, *args, **kwargs)
     return wrapped
 
-# should invoke ChatAction.typing
-
-
 def types(func):
+    """Used by bot handlers that respond with text.
+    ChatAction.Typing is called which makes the bot look like it's typing"""
     @wraps(func)
     def wrapped(bot, update, *args, **kwargs):
         bot.send_chat_action(
@@ -60,11 +59,12 @@ def types(func):
 conn = None
 import time
 
-# TODO: move this function
-# Returns false if any of the required environment variables are not set
-
 
 def check_env_vars_all_loaded() -> Tuple[bool, str]:
+    """Checks required environment variables and returns false if required env vars are not set
+    """
+    # TODO: move this function
+
     env_vars = [
         'BOT_TOKEN',
         'LOG_LEVEL',
@@ -310,10 +310,8 @@ def error(bot, update, error):
     logger.warning('Update "%s" caused error "%s"', update, error)
 
 
-""" this command runs last and lets the user know their command was not understood """
-
-
 def unknown(bot, update):
+    """This command runs last and lets the user know their command was not understood """
     bot.send_message(chat_id=update.message.chat_id,
                      text="Sorry, I didn't understand that command.")
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -3,34 +3,37 @@ import os
 import sys
 import pickle
 import random
-import psycopg2 # postgresql python 
+import psycopg2  # postgresql python
 import re
 
 from telegram.ext import Filters, CommandHandler, MessageHandler, Updater
 import telegram as tg
 from typing import Dict, NewType, Tuple, List
 
-from models import User, User_in_chat, Telegram_chat, Telegram_message,user_from_tg_user
+from models import User, User_in_chat, Telegram_chat, Telegram_message, user_from_tg_user
 from postgres_funcs import *
 
 log_level = os.environ.get('LOG_LEVEL')
 level = None
 if log_level == "debug":
-    level=logging.DEBUG
+    level = logging.DEBUG
 elif log_level == "info":
-    level=logging.INFO
+    level = logging.INFO
 else:
-    level=logging.INFO
+    level = logging.INFO
 
-logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+logging.basicConfig(
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     level=level)
 logger = logging.getLogger(__name__)
 
-version = '1.04' # TODO: make this automatic
+version = '1.04'  # TODO: make this automatic
 changelog_url = 'https://schafezp.com/schafezp/txkarmabot/blob/master/CHANGELOG.md'
 
 from functools import wraps
 LIST_OF_ADMINS = [65278791]
+
+
 def restricted(func):
     @wraps(func)
     def wrapped(bot, update, *args, **kwargs):
@@ -41,42 +44,61 @@ def restricted(func):
         return func(bot, update, *args, **kwargs)
     return wrapped
 
-#should invoke ChatAction.typing
+# should invoke ChatAction.typing
+
+
 def types(func):
     @wraps(func)
     def wrapped(bot, update, *args, **kwargs):
-        bot.send_chat_action(chat_id=update.message.chat_id, action=tg.ChatAction.TYPING)
+        bot.send_chat_action(
+            chat_id=update.message.chat_id,
+            action=tg.ChatAction.TYPING)
         return func(bot, update, *args, **kwargs)
     return wrapped
+
 
 conn = None
 import time
 
-#TODO: move this function
-#Returns false if any of the required environment variables are not set
-def check_env_vars_all_loaded() -> Tuple[bool,str]:
-    env_vars = ['BOT_TOKEN','LOG_LEVEL','POSTGRES_USER','POSTGRES_PASS','POSTGRES_DB', ]
+# TODO: move this function
+# Returns false if any of the required environment variables are not set
+
+
+def check_env_vars_all_loaded() -> Tuple[bool, str]:
+    env_vars = [
+        'BOT_TOKEN',
+        'LOG_LEVEL',
+        'POSTGRES_USER',
+        'POSTGRES_PASS',
+        'POSTGRES_DB',
+    ]
     logger.info("Environment Variables:")
     for var in env_vars:
         val = os.environ.get(var)
         if val is None or val == '':
-            logger.info('Variable: {} Value: {}'.format(var," VALUE MISSING. EXITING"))
-            return (False,var)
+            logger.info(
+                'Variable: {} Value: {}'.format(
+                    var, " VALUE MISSING. EXITING"))
+            return (False, var)
         else:
-            logger.info('Variable: {} Value: {}'.format(var,val))
+            logger.info('Variable: {} Value: {}'.format(var, val))
 
-    return (True,var)
+    return (True, var)
 
 
-
-#TODO:move this logic elsewhere and handle singleton connection in different way
+# TODO:move this logic elsewhere and handle singleton connection in
+# different way
 while conn is None:
     try:
         host = os.environ.get("POSTGRES_HOSTNAME")
         database = os.environ.get("POSTGRES_DB")
         user = os.environ.get("POSTGRES_USER")
         password = os.environ.get("POSTGRES_PASS")
-        conn = psycopg2.connect(host=host, database=database, user=user, password=password)
+        conn = psycopg2.connect(
+            host=host,
+            database=database,
+            user=user,
+            password=password)
     except psycopg2.OperationalError as oe:
         print(oe)
         time.sleep(1)
@@ -89,139 +111,197 @@ def reply(bot: tg.Bot, update: tg.Update):
     replying_user = user_from_tg_user(update.message.from_user)
     chat_id = str(update.message.chat_id)
     chat = Telegram_chat(chat_id, update.message.chat.title)
-    original_message = Telegram_message(update.message.reply_to_message.message_id, chat.chat_id, reply_user.id, update.message.reply_to_message.text)
-    reply_message = Telegram_message(update.message.message_id, chat.chat_id, replying_user.id, update.message.text)
+    original_message = Telegram_message(
+        update.message.reply_to_message.message_id,
+        chat.chat_id,
+        reply_user.id,
+        update.message.reply_to_message.text)
+    reply_message = Telegram_message(
+        update.message.message_id,
+        chat.chat_id,
+        replying_user.id,
+        update.message.text)
     reply_text = reply_message.message_text
 
     if re.match("^([\+pP][1-9][0-9]*|[Pp]{2}).*", reply_text):
-        #if user tried to +1 self themselves
-        #chat id is user_id when the user is talking 1 on 1 with the bot
+        # if user tried to +1 self themselves
+        # chat id is user_id when the user is talking 1 on 1 with the bot
         if(replying_user.id == update.message.reply_to_message.from_user.id and chat_id != str(reply_user.id)):
-            witty_responses = [" how could you +1 yourself?", " what do you think you're doing?", " is your post really worth +1ing yourself?", " you won't get any goodie points for that", " try +1ing someone else instead of yourself!", " who are you to +1 yourself?", " beware the Jabberwocky", " have a 🍪!", " you must give praise. May he 🍔melt🍔! "]
+            witty_responses = [
+                " how could you +1 yourself?",
+                " what do you think you're doing?",
+                " is your post really worth +1ing yourself?",
+                " you won't get any goodie points for that",
+                " try +1ing someone else instead of yourself!",
+                " who are you to +1 yourself?",
+                " beware the Jabberwocky",
+                " have a 🍪!",
+                " you must give praise. May he 🍔melt🍔! "]
             response = random.choice(witty_responses)
             message = f"{replying_user.first_name}{response}"
             bot.send_message(chat_id=chat_id, text=message)
-        else: # user +1 someone else
-            user_reply_to_message(replying_user,reply_user, chat, original_message, reply_message, 1,conn)
+        else:  # user +1 someone else
+            user_reply_to_message(
+                replying_user,
+                reply_user,
+                chat,
+                original_message,
+                reply_message,
+                1,
+                conn)
             logger.debug("user replying other user")
             logger.debug(replying_user)
             logger.debug(reply_user)
-    elif re.match("^([\-mM][1-9][0-9]*|[Dd]{2}).*", reply_text) : #user -1 someone else
-        user_reply_to_message(replying_user, reply_user, chat, original_message, reply_message, -1,conn)
+    # user -1 someone else
+    elif re.match("^([\-mM][1-9][0-9]*|[Dd]{2}).*", reply_text):
+        user_reply_to_message(replying_user, reply_user,
+                              chat, original_message, reply_message, -1, conn)
         logger.debug("user replying other user")
         logger.debug(replying_user)
         logger.debug(reply_user)
-        
+
 
 def start(bot, update):
-    bot.send_message(chat_id=update.message.chat_id, text="I'm a bot, please talk to me!")
+    bot.send_message(
+        chat_id=update.message.chat_id,
+        text="I'm a bot, please talk to me!")
+
 
 @types
-def show_version(bot,update,args):
+def show_version(bot, update, args):
     message = "Version: " + version + "\n" + "Bot powered by Python."
-    #harder to hack the bot if source code is obfuscated :p
+    # harder to hack the bot if source code is obfuscated :p
     #message = message + "\nChangelog found at: " + changelog_url
     bot.send_message(chat_id=update.message.chat_id, text=message)
 
+
 @types
-def show_user_stats(bot,update,args):
-    #TODO: remove this boiler plate code somehow
-    #without this if this is the first command run alone with the bot it will fail due to psycopg2.IntegrityError: insert or update on table "command_used" violates foreign key constraint "command_used_chat_id_fkey"
-    chat = Telegram_chat(str(update.message.chat_id), update.message.chat.title)
-    save_or_create_chat(chat,conn)
+def show_user_stats(bot, update, args):
+    # TODO: remove this boiler plate code somehow
+    # without this if this is the first command run alone with the bot it will
+    # fail due to psycopg2.IntegrityError: insert or update on table
+    # "command_used" violates foreign key constraint
+    # "command_used_chat_id_fkey"
+    chat = Telegram_chat(str(update.message.chat_id),
+                         update.message.chat.title)
+    save_or_create_chat(chat, conn)
 
     user_id = update.message.from_user.id
     chat_id = str(update.message.chat_id)
     if len(args) != 1:
-        bot.send_message(chat_id=update.message.chat_id, text="use command like: /userinfo username")
+        bot.send_message(
+            chat_id=update.message.chat_id,
+            text="use command like: /userinfo username")
         return
     username = args[0]
     if username[0] == "@":
         username = username[1:]
-        
-    use_command('userinfo',user_from_tg_user(update.message.from_user), str(update.message.chat_id), arguments=username)
+
+    use_command(
+        'userinfo', user_from_tg_user(
+            update.message.from_user), str(
+            update.message.chat_id), arguments=username)
 
     message = None
     try:
-        result = get_user_stats(username,chat_id, conn)
+        result = get_user_stats(username, chat_id, conn)
         message = """Username: {:s} Karma: {:d}
         Karma given out stats:
         Upvotes, Downvotes, Total Votes, Net Karma
         {:d}, {:d}, {:d}, {:d}"""
-        message = message.format(result['username'], result['karma'],
-        result['upvotes_given'], result['downvotes_given'],
-        result['total_votes_given'], result['net_karma_given'])
+        message = message.format(
+            result['username'],
+            result['karma'],
+            result['upvotes_given'],
+            result['downvotes_given'],
+            result['total_votes_given'],
+            result['net_karma_given'])
     except UserNotFound as _:
         message = f"No user with username: {username}"
-    
+
     bot.send_message(chat_id=update.message.chat_id, text=message)
-    
-#TODO: replace this with an annotation maybe?
-def use_command(command: str,user: User, chat_id: str, arguments=""):
-    create_chat_if_not_exists(chat_id,conn)
-    save_or_create_user(user,conn)
+
+# TODO: replace this with an annotation maybe?
+
+
+def use_command(command: str, user: User, chat_id: str, arguments=""):
+    create_chat_if_not_exists(chat_id, conn)
+    save_or_create_user(user, conn)
     insertcmd = """INSERT INTO command_used (command,arguments,user_id,chat_id) VALUES (%s,%s,%s,%s)"""
     with conn:
         with conn.cursor() as crs:
-            crs.execute(insertcmd,[command,arguments,user.id,chat_id])
+            crs.execute(insertcmd, [command, arguments, user.id, chat_id])
+
 
 @types
-def show_karma(bot,update,args):
-    use_command('showkarma',user_from_tg_user(update.message.from_user), str(update.message.chat_id))
+def show_karma(bot, update, args):
+    use_command(
+        'showkarma', user_from_tg_user(
+            update.message.from_user), str(
+            update.message.chat_id))
     logger.debug("Chat id: " + str(update.message.chat_id))
 
-    #returns username, first_name, karma
-    rows : List[Tuple[str,str,int]] = get_karma_for_users_in_chat(str(update.message.chat_id),conn)
+    # returns username, first_name, karma
+    rows: List[Tuple[str, str, int]] = get_karma_for_users_in_chat(
+        str(update.message.chat_id), conn)
     rows.sort(key=lambda user: user[2], reverse=True)
-    #use firstname if username not set
+    # use firstname if username not set
+
     def cleanrow(user):
         if user[0] is None:
-            return (user[1],user[2])
+            return (user[1], user[2])
         else:
-            return (user[0],user[2])
+            return (user[0], user[2])
     message_rows = []
     idx = 0
-    for user in map(cleanrow,rows):
+    for user in map(cleanrow, rows):
         row = f"{user[0]}: {user[1]}"
         if idx == 0:
-            row = '🥇' + row 
+            row = '🥇' + row
         elif idx == 1:
-            row = '🥈' + row 
+            row = '🥈' + row
         elif idx == 2:
-            row = '🥉' + row 
+            row = '🥉' + row
         idx = idx + 1
         message_rows.append(row)
     message = "\n".join(message_rows)
 
     if message != '':
-        message = "Username: Karma\n" + message # TODO: figure out a better way to add this heading
+        # TODO: figure out a better way to add this heading
+        message = "Username: Karma\n" + message
     else:
         message = "Oops I didn't find any karma"
 
     bot.send_message(chat_id=update.message.chat_id, text=message)
 
+
 @types
-def show_chat_info(bot,update,args):
-    use_command('chatinfo',user_from_tg_user(update.message.from_user), str(update.message.chat_id))
+def show_chat_info(bot, update, args):
+    use_command(
+        'chatinfo', user_from_tg_user(
+            update.message.from_user), str(
+            update.message.chat_id))
     chat_id = str(update.message.chat_id)
     title = update.message.chat.title
     if title is None:
         title = "No Title"
     result = get_chat_info(chat_id, conn)
-    message = "Chat: {:s}.\n Number of Users with Karma: {:d}\n Total Reply Count: {:d}".format(title,
-    result['user_with_karma_count'], result['reply_count'])
+    message = "Chat: {:s}.\n Number of Users with Karma: {:d}\n Total Reply Count: {:d}".format(
+        title, result['user_with_karma_count'], result['reply_count'])
     bot.send_message(chat_id=update.message.chat_id, text=message)
 
+
 @restricted
-def am_I_admin(bot,update,args):
+def am_I_admin(bot, update, args):
     message = "yes you are an admin"
     bot.send_message(chat_id=update.message.chat_id, text=message)
 
 
-def show_karma_personally(bot,update,args):
-    #TODO:check if this is a 1 on 1 message handler
-    #offer choice to user of which chat they want to see the karma totals of
-    #user clicks on button to choose chat (similar to BotFather) then bot responds with karma for that chat
+def show_karma_personally(bot, update, args):
+    # TODO:check if this is a 1 on 1 message handler
+    # offer choice to user of which chat they want to see the karma totals of
+    # user clicks on button to choose chat (similar to BotFather) then bot
+    # responds with karma for that chat
     return
 
 
@@ -231,8 +311,11 @@ def error(bot, update, error):
 
 
 """ this command runs last and lets the user know their command was not understood """
+
+
 def unknown(bot, update):
-    bot.send_message(chat_id=update.message.chat_id, text="Sorry, I didn't understand that command.")
+    bot.send_message(chat_id=update.message.chat_id,
+                     text="Sorry, I didn't understand that command.")
 
 
 def main():
@@ -257,16 +340,19 @@ def main():
     showkarma_handler = CommandHandler('showkarma', show_karma, pass_args=True)
     dispatcher.add_handler(showkarma_handler)
 
-    show_user_handler = CommandHandler('userinfo', show_user_stats, pass_args=True)
+    show_user_handler = CommandHandler(
+        'userinfo', show_user_stats, pass_args=True)
     dispatcher.add_handler(show_user_handler)
 
-    chat_info_handler = CommandHandler('chatinfo', show_chat_info, pass_args=True)
+    chat_info_handler = CommandHandler(
+        'chatinfo', show_chat_info, pass_args=True)
     dispatcher.add_handler(chat_info_handler)
 
     am_I_admin_handler = CommandHandler('amiadmin', am_I_admin, pass_args=True)
     dispatcher.add_handler(am_I_admin_handler)
 
-    showversion_handler = CommandHandler('version', show_version, pass_args=True)
+    showversion_handler = CommandHandler(
+        'version', show_version, pass_args=True)
     dispatcher.add_handler(showversion_handler)
 
     dispatcher.add_error_handler(error)
@@ -278,8 +364,9 @@ def main():
 
     cursor.execute("SELECT * FROM pg_catalog.pg_tables;")
     many = cursor.fetchall()
-    public_tables = list(map(lambda x: x[1], filter(lambda x: x[0] == 'public', many)))
-    logger.info("public_tables: "+ str(public_tables))
+    public_tables = list(
+        map(lambda x: x[1], filter(lambda x: x[0] == 'public', many)))
+    logger.info("public_tables: " + str(public_tables))
 
     updater.idle()
 

--- a/src/models.py
+++ b/src/models.py
@@ -1,30 +1,42 @@
 import telegram as tg
 from typing import Optional
 
-def user_from_tg_user(user : tg.User):
-    return User(user.id,user.username, user.first_name, user.last_name)
-def message_from_tg_message(message :tg.Message):
-    return Telegram_message(message.message_id, message.chat.id, message.from_user.id, message.text)
+
+def user_from_tg_user(user: tg.User):
+    return User(user.id, user.username, user.first_name, user.last_name)
+
+
+def message_from_tg_message(message: tg.Message):
+    return Telegram_message(
+        message.message_id,
+        message.chat.id,
+        message.from_user.id,
+        message.text)
+
 
 class User(object):
     """
     A representation of a telegram user
     """
-    id :int
+    id: int
     __karma: int
     first_name: str
     last_name: Optional[str]
-    username : Optional[str]
+    username: Optional[str]
 
-
-    def __init__(self, id:int, username: str, first_name:str, last_name:str):
+    def __init__(
+            self,
+            id: int,
+            username: str,
+            first_name: str,
+            last_name: str):
         self.__karma = 0
         self.id = id
         self.username = username
         self.first_name = first_name
         self.last_name = last_name
 
-    #TODO: write function to create User from there params
+    # TODO: write function to create User from there params
     """ def __init__(self, user: tg.User ):
         self.__karma = 0
         self.id : int = user.id
@@ -32,29 +44,38 @@ class User(object):
         self.last_name : Optional[str] = user.last_name
         self.username : Optional[str] = user.username """
 
-
     def get_karma(self):
         return self.__karma
+
     def get_username(self):
         return self.username
+
     def give_karma(self):
         self.__karma = self.__karma + 1
+
     def remove_karma(self):
         self.__karma = self.__karma - 1
+
     def get_user_id(self):
         return self.id
+
     def get_first_name(self):
         return self.first_name
+
     def get_last_name(self):
         return self.last_name
+
     def __str__(self):
         if self.username is not None:
-            message = "Username: " + self.username + " karma: " + str(self.get_karma())
-            #clean this logic up
-            message = message + " first: " + str(self.get_first_name()) + " last: " + str(self.get_last_name())
+            message = "Username: " + self.username + \
+                " karma: " + str(self.get_karma())
+            # clean this logic up
+            message = message + " first: " + \
+                str(self.get_first_name()) + " last: " + str(self.get_last_name())
             return message
         else:
-            return "First Name: " + self.first_name + " karma: " + str(self.get_karma())
+            return "First Name: " + self.first_name + \
+                " karma: " + str(self.get_karma())
 
 
 class User_in_chat(object):
@@ -62,28 +83,38 @@ class User_in_chat(object):
     chat_id: int
     karma: int
 
-    def __init__(self, user_id : int, chat_id: int, karma: int):
+    def __init__(self, user_id: int, chat_id: int, karma: int):
         self.user_id = user_id
         self.chat_id = chat_id
         self.karma = karma
 
+
 class Telegram_chat(object):
     chat_id: str
     chat_name: str
-    def __init__(self,chat_id: str, chat_name: str):
+
+    def __init__(self, chat_id: str, chat_name: str):
         self.chat_id = chat_id
         self.chat_name = chat_name
-        
+
+
 class Telegram_message(object):
     message_id: int
     chat_id: int
     author_user_id: int
     message_text: str
-    def __init__(self, message_id: int, chat_id: int, author_user_id: int, message_text: str):
+
+    def __init__(
+            self,
+            message_id: int,
+            chat_id: int,
+            author_user_id: int,
+            message_text: str):
         self.message_id = message_id
         self.message_text = message_text
         self.chat_id = chat_id
         self.author_user_id = author_user_id
+
 
 class User_reacted_to_message(object):
     id: int
@@ -91,7 +122,14 @@ class User_reacted_to_message(object):
     message_id: int
     react_score: int
     react_message_id: str
-    def __init__(self,id,user_in_chat_id, message_id, react_score, react_message_id):
+
+    def __init__(
+            self,
+            id,
+            user_in_chat_id,
+            message_id,
+            react_score,
+            react_message_id):
         self.id = id
         self.user_in_chat_id = user_in_chat_id
         self.message_id = message_id

--- a/src/postgres_funcs.py
+++ b/src/postgres_funcs.py
@@ -2,58 +2,74 @@ from models import User, User_in_chat, Telegram_chat, Telegram_message
 from typing import Optional, Tuple, List, Dict
 import logging
 
+
 class UserNotFound(Exception):
     pass
+
+
 class NoUserReactsFound(Exception):
     pass
 
+
 def get_user_by_user_id(user_id: int, conn) -> User:
     with conn:
-        with conn.cursor() as crs: #I would love type hints here but psycopg2.cursor isn't a defined class
+        with conn.cursor() as crs:  # I would love type hints here but psycopg2.cursor isn't a defined class
             selectcmd = "SELECT user_id, username, first_name, last_name from telegram_user tu where tu.user_id=%s"
             crs.execute(selectcmd, [user_id])
             res = crs.fetchone()
-            return User(res[0],res[1],res[2],res[3])
+            return User(res[0], res[1], res[2], res[3])
+
+
 def get_user_by_username(username: str, conn) -> User:
     with conn:
-        with conn.cursor() as crs: #I would love type hints here but psycopg2.cursor isn't a defined class
+        with conn.cursor() as crs:  # I would love type hints here but psycopg2.cursor isn't a defined class
             selectcmd = "SELECT user_id, username, first_name, last_name from telegram_user tu where tu.username=%s"
             crs.execute(selectcmd, [username])
             res = crs.fetchone()
-            return User(res[0],res[1],res[2],res[3])
+            return User(res[0], res[1], res[2], res[3])
 
-#TODO: pass in user_id
-#TODO: implement this as a stored procedure instead since there is a number of round trips
-#TODO: return some structure and then parse it
+# TODO: pass in user_id
+# TODO: implement this as a stored procedure instead since there is a number of round trips
+# TODO: return some structure and then parse it
+
+
 def get_user_stats(username: str, chat_id: str, conn) -> Dict:
     user = get_user_by_username(username, conn)
     if user is None:
         raise UserNotFound()
-    user_has_reacts = did_user_react_to_messages(username,conn)
-    karma = get_karma_for_user_in_chat(username,chat_id,conn)
-    if karma is None: karma = 0
-    
+    user_has_reacts = did_user_react_to_messages(username, conn)
+    karma = get_karma_for_user_in_chat(username, chat_id, conn)
+    if karma is None:
+        karma = 0
+
     output_dict = None
     if not user_has_reacts:
-        output_dict = {'username':username, 'karma': karma,
-        'upvotes_given': 0,'downvotes_given' : 0,'total_votes_given': 0,'net_karma_given': 0 }
+        output_dict = {
+            'username': username,
+            'karma': karma,
+            'upvotes_given': 0,
+            'downvotes_given': 0,
+            'total_votes_given': 0,
+            'net_karma_given': 0}
     else:
-        #how many reacts given out by user
+        # how many reacts given out by user
         how_many_user_reacted_to_stats = """select react_score, count(react_score)from
             (select username, message_id, react_score, react_message_id  from telegram_user tu
             left join user_reacted_to_message urtm on urtm.user_id=tu.user_id
             where tu.username = %s) as sub left join telegram_message tm on  tm.message_id= sub.message_id
             where tm.chat_id=%s group by react_score;"""
-        #TODO: implement how many reacts recieved by user
+        # TODO: implement how many reacts recieved by user
         how_many_reacted_to_user_stats = """"""
         negative_karma_given = 0
         positive_karma_given = 0
         result = None
         with conn:
             with conn.cursor() as crs:
-                crs.execute(how_many_user_reacted_to_stats,[username,chat_id])
+                crs.execute(
+                    how_many_user_reacted_to_stats, [
+                        username, chat_id])
                 rows = crs.fetchall()
-                #there are only two rows
+                # there are only two rows
                 for row in rows:
                     if row[0] == -1:
                         negative_karma_given = int(row[1])
@@ -61,15 +77,17 @@ def get_user_stats(username: str, chat_id: str, conn) -> Dict:
                         positive_karma_given = int(row[1])
                 result = crs.fetchone()
 
-        
-        #TODO: make this output type a class instead to bundle this info
-        output_dict = {'username':username, 'karma': karma,
-        'upvotes_given': positive_karma_given,
-        'downvotes_given' : negative_karma_given,
-        'total_votes_given': positive_karma_given + negative_karma_given,
-        'net_karma_given': positive_karma_given- negative_karma_given }
+        # TODO: make this output type a class instead to bundle this info
+        output_dict = {
+            'username': username,
+            'karma': karma,
+            'upvotes_given': positive_karma_given,
+            'downvotes_given': negative_karma_given,
+            'total_votes_given': positive_karma_given + negative_karma_given,
+            'net_karma_given': positive_karma_given - negative_karma_given}
     return output_dict
-        
+
+
 def get_chat_info(chat_id: str, conn) -> Dict:
     count_reacts_cmd = """select count(tm.message_id) from user_reacted_to_message urtm
 left join telegram_message tm ON tm.message_id = urtm.message_id
@@ -84,23 +102,24 @@ where tm.chat_id=%s"""
             reply_count = None
             user_with_karma_count = None
             message = ""
-            crs.execute(count_reacts_cmd,[chat_id])
+            crs.execute(count_reacts_cmd, [chat_id])
             result = crs.fetchone()
             if result is not None:
                 reply_count = result[0]
             else:
                 reply_count = 0
 
-            crs.execute(select_user_with_karma_count,[chat_id])
+            crs.execute(select_user_with_karma_count, [chat_id])
             result = crs.fetchone()
             if result is not None:
                 user_with_karma_count = result[0]
             else:
                 user_with_karma_count = 0
-            return {'reply_count': reply_count, 'user_with_karma_count': user_with_karma_count}
+            return {'reply_count': reply_count,
+                    'user_with_karma_count': user_with_karma_count}
 
 
-#TODO: use user_id instead of username
+# TODO: use user_id instead of username
 def did_user_react_to_messages(username: str, conn) -> bool:
     select_user_replies = """select username, message_id, react_score, react_message_id  from telegram_user tu
             left join user_reacted_to_message urtm on urtm.user_id=tu.user_id
@@ -108,17 +127,21 @@ def did_user_react_to_messages(username: str, conn) -> bool:
     reacted_messages_result = None
     with conn:
         with conn.cursor() as crs:
-            crs.execute(select_user_replies,[username])
+            crs.execute(select_user_replies, [username])
             reacted_messages_result = crs.fetchone()
             return reacted_messages_result is not None
-#TODO: user user_id            
-def get_user_react_stats(username: str, conn ) -> bool:
+# TODO: user user_id
+
+
+def get_user_react_stats(username: str, conn) -> bool:
     print()
-def save_or_create_user(user : User,conn) -> User:
+
+
+def save_or_create_user(user: User, conn) -> User:
     with conn:
-        with conn.cursor() as crs: #I would love type hints here but psycopg2.cursor isn't a defined class
+        with conn.cursor() as crs:  # I would love type hints here but psycopg2.cursor isn't a defined class
             selectcmd = "SELECT user_id, username, first_name, last_name from telegram_user tu where tu.user_id=%s"
-            #TODO: upsert to update values otherwise username, firstname, lastname wont ever change
+            # TODO: upsert to update values otherwise username, firstname, lastname wont ever change
             #print("user with id: " + str(user_id) + "  not found: creating user")
             insertcmd = """INSERT into telegram_user
             (user_id, username, first_name, last_name) VALUES (%s,%s,%s,%s)
@@ -127,43 +150,59 @@ def save_or_create_user(user : User,conn) -> User:
             first_name = EXCLUDED.first_name,
             last_name = EXCLUDED.last_name
             """
-            crs.execute(insertcmd,[user.get_user_id(),user.get_username(),user.get_first_name(),user.get_last_name()])
+            crs.execute(insertcmd,
+                        [user.get_user_id(),
+                         user.get_username(),
+                            user.get_first_name(),
+                            user.get_last_name()])
             conn.commit()
-            crs.execute(selectcmd,[user.get_user_id()])
+            crs.execute(selectcmd, [user.get_user_id()])
             (user_id, username, first_name, last_name) = crs.fetchone()
-            return User(user_id,username,first_name,last_name)
+            return User(user_id, username, first_name, last_name)
+
+
 def does_chat_exist(chat_id: str, conn):
     with conn:
-        with conn.cursor() as crs: #I would love type hints here but psycopg2.cursor isn't a defined class
+        with conn.cursor() as crs:  # I would love type hints here but psycopg2.cursor isn't a defined class
             selectcmd = "SELECT chat_id, chat_name FROM telegram_chat tc where tc.chat_id=%s"
-            crs.execute(selectcmd,[chat_id])
+            crs.execute(selectcmd, [chat_id])
             return crs.fetchone() is not None
+
 
 def save_or_create_chat(chat: Telegram_chat, conn):
     with conn:
-        with conn.cursor() as crs: #I would love type hints here but psycopg2.cursor isn't a defined class
-            insertcmd = """INSERT into telegram_chat 
+        with conn.cursor() as crs:  # I would love type hints here but psycopg2.cursor isn't a defined class
+            insertcmd = """INSERT into telegram_chat
             (chat_id, chat_name) VALUES (%s,%s)
-            ON CONFLICT (chat_id) DO UPDATE 
+            ON CONFLICT (chat_id) DO UPDATE
             SET chat_name = EXCLUDED.chat_name"""
             crs.execute(insertcmd, [chat.chat_id, chat.chat_name])
             conn.commit()
-def create_chat_if_not_exists(chat_id: int,conn):
+
+
+def create_chat_if_not_exists(chat_id: int, conn):
     with conn:
-        with conn.cursor() as crs: #I would love type hints here but psycopg2.cursor isn't a defined class
-            insertcmd = """INSERT into telegram_chat 
+        with conn.cursor() as crs:  # I would love type hints here but psycopg2.cursor isn't a defined class
+            insertcmd = """INSERT into telegram_chat
             (chat_id) VALUES (%s)
             ON CONFLICT (chat_id) DO NOTHING"""
             crs.execute(insertcmd, [chat_id])
             conn.commit()
 
-#if user did not have a karma before, karma will be set to change_karma
-def save_or_create_user_in_chat(user: User, chat_id: str, conn, change_karma=0) -> User_in_chat:
+# if user did not have a karma before, karma will be set to change_karma
+
+
+def save_or_create_user_in_chat(
+        user: User,
+        chat_id: str,
+        conn,
+        change_karma=0) -> User_in_chat:
     with conn:
-        with conn.cursor() as crs: #I would love type hints here but psycopg2.cursor isn't a defined class
-            #TODO: instead of select first, do insert and then trap exception if primary key exists
+        with conn.cursor() as crs:  # I would love type hints here but psycopg2.cursor isn't a defined class
+            # TODO: instead of select first, do insert and then trap exception
+            # if primary key exists
             selectcmd = "SELECT user_id, chat_id, karma FROM user_in_chat uic where uic.user_id=%s AND uic.chat_id=%s"
-            crs.execute(selectcmd,[user.id, chat_id,])
+            crs.execute(selectcmd, [user.id, chat_id, ])
 
             result = crs.fetchone()
 
@@ -173,25 +212,37 @@ def save_or_create_user_in_chat(user: User, chat_id: str, conn, change_karma=0) 
                 RETURNING karma
                 """
 
-            #TODO: used named parameters instead of %s to not have to repeat these params
-            crs.execute(insertcmd_karma,
-            [user.get_user_id(),chat_id, change_karma,change_karma])
+            # TODO: used named parameters instead of %s to not have to repeat
+            # these params
+            crs.execute(
+                insertcmd_karma, [
+                    user.get_user_id(), chat_id, change_karma, change_karma])
 
             row = crs.fetchone()
             conn.commit()
             karma = row[0]
-            return User_in_chat(user.id,chat_id,karma)
+            return User_in_chat(user.id, chat_id, karma)
 
-#message tg.Message
-#reply_message comes after and is the reply
-def user_reply_to_message(user: User,reply_to_user: User, chat: Telegram_chat , original_message : Telegram_message, reply_message : Telegram_message, karma : int, conn):
-    user: User = save_or_create_user(user,conn)
-    reply_to_user: User = save_or_create_user(reply_to_user,conn)
-    if not does_chat_exist(chat.chat_id,conn):
+# message tg.Message
+# reply_message comes after and is the reply
+
+
+def user_reply_to_message(
+        user: User,
+        reply_to_user: User,
+        chat: Telegram_chat,
+        original_message: Telegram_message,
+        reply_message: Telegram_message,
+        karma: int,
+        conn):
+    user: User = save_or_create_user(user, conn)
+    reply_to_user: User = save_or_create_user(reply_to_user, conn)
+    if not does_chat_exist(chat.chat_id, conn):
         save_or_create_chat(chat, conn)
 
     uic: User_in_chat = save_or_create_user_in_chat(user, chat.chat_id, conn)
-    reply_to_uic: User_in_chat = save_or_create_user_in_chat(reply_to_user, chat.chat_id, conn)
+    reply_to_uic: User_in_chat = save_or_create_user_in_chat(
+        reply_to_user, chat.chat_id, conn)
 
     insert_message = """INSERT INTO telegram_message
     (message_id,chat_id, author_user_id, message_text)
@@ -204,58 +255,80 @@ def user_reply_to_message(user: User,reply_to_user: User, chat: Telegram_chat , 
     (user_id,message_id,react_score,react_message_id)
     VALUES (%s,%s,%s,%s)"""
 
-    #TODO: manage this with a constraint rather than having to select
+    # TODO: manage this with a constraint rather than having to select
     selecturtmunique = """SELECT react_score from user_reacted_to_message urtm where urtm.user_id=%s and urtm.message_id=%s"""
-    #none if user hasn't reacted yet
+    # none if user hasn't reacted yet
     user_previous_react = None
     with conn:
         with conn.cursor() as crs:
             args_select_urtm = [uic.user_id, original_message.message_id]
-            crs.execute(selecturtmunique,args_select_urtm)
+            crs.execute(selecturtmunique, args_select_urtm)
             result = crs.fetchone()
             if result is not None:
                 user_previous_react = result[0]
 
-    #TODO: add gaurd for karma == 1 or == -1 up higher
+    # TODO: add gaurd for karma == 1 or == -1 up higher
     if user_previous_react is None or user_previous_react != karma:
         if(karma == 1 or karma == -1):
-            save_or_create_user_in_chat(reply_to_user,chat.chat_id, conn, change_karma=karma)
+            save_or_create_user_in_chat(
+                reply_to_user, chat.chat_id, conn, change_karma=karma)
         else:
-            logging.info(f"invalid karma: {karma} passed to user_reply_to_message")
+            logging.info(
+                f"invalid karma: {karma} passed to user_reply_to_message")
         with conn:
             with conn.cursor() as crs:
-                args_reply_message = [reply_message.message_id, chat.chat_id, uic.user_id, reply_message.message_text]
-                args_original_message = [original_message.message_id, chat.chat_id, original_message.author_user_id, original_message.message_text]
-                crs.execute(insert_message,args_reply_message)
-                crs.execute(insert_message,args_original_message)
-                argsurtm = [uic.user_id, original_message.message_id, karma, reply_message.message_id]
-                crs.execute(inserturtm,argsurtm)
+                args_reply_message = [
+                    reply_message.message_id,
+                    chat.chat_id,
+                    uic.user_id,
+                    reply_message.message_text]
+                args_original_message = [
+                    original_message.message_id,
+                    chat.chat_id,
+                    original_message.author_user_id,
+                    original_message.message_text]
+                crs.execute(insert_message, args_reply_message)
+                crs.execute(insert_message, args_original_message)
+                argsurtm = [
+                    uic.user_id,
+                    original_message.message_id,
+                    karma,
+                    reply_message.message_id]
+                crs.execute(inserturtm, argsurtm)
 
 
-def get_karma_for_user_in_chat(username: str, chat_id: str,conn) -> Optional[int]:
+def get_karma_for_user_in_chat(
+        username: str,
+        chat_id: str,
+        conn) -> Optional[int]:
     cmd = """select karma from telegram_user tu
         LEFT JOIN user_in_chat uic ON uic.user_id=tu.user_id
         where tu.username=%s AND uic.chat_id=%s"""
     with conn:
         with conn.cursor() as crs:
-            #TODO: handle | psycopg2.ProgrammingError: relation "user_in_chat" does not exist
-            crs.execute(cmd,[username,chat_id])
+            # TODO: handle | psycopg2.ProgrammingError: relation "user_in_chat"
+            # does not exist
+            crs.execute(cmd, [username, chat_id])
             result = crs.fetchone()
             if result is not None:
                 return result[0]
             return result
 
-def get_karma_for_users_in_chat(chat_id: str,conn) -> List[Tuple[str,str,int]]:
-    cmd = """select username, first_name, karma from telegram_user tu 
+
+def get_karma_for_users_in_chat(
+        chat_id: str, conn) -> List[Tuple[str, str, int]]:
+    cmd = """select username, first_name, karma from telegram_user tu
         LEFT JOIN user_in_chat uic ON uic.user_id=tu.user_id
         where uic.chat_id=%s;"""
     with conn:
         with conn.cursor() as crs:
-            #TODO: handle | psycopg2.ProgrammingError: relation "user_in_chat" does not exist
-            crs.execute(cmd,[chat_id])
+            # TODO: handle | psycopg2.ProgrammingError: relation "user_in_chat"
+            # does not exist
+            crs.execute(cmd, [chat_id])
             return crs.fetchall()
 
-def get_message_responses_for_user_in_chat(user_id: int, chat_id: int,conn):
+
+def get_message_responses_for_user_in_chat(user_id: int, chat_id: int, conn):
     cmd = """    SELECT sub3.user_id, sub3.message_id, sub3.response_text AS message_text, urtm.react_score,
         urtm.react_message_id, sub3.username AS responder_username, sub3.first_name AS responder_first_name,
          sub3.last_name AS responder_last_name  FROM (
@@ -271,5 +344,5 @@ def get_message_responses_for_user_in_chat(user_id: int, chat_id: int,conn):
     LEFT JOIN user_reacted_to_message urtm ON urtm.message_id = sub3.message_id;"""
     with conn:
         with conn.cursor() as crs:
-            crs.execute(cmd,[user_id,chat_id])
+            crs.execute(cmd, [user_id, chat_id])
             return crs.fetchall()


### PR DESCRIPTION
I used the command
```
autopep8 --in-place --aggressive --aggressive src/bot.py
autopep8 --in-place --aggressive --aggressive src/postgres_funcs.py
```
To automatically pep format the project. 

This might also be a good time to add support for #15 to run the autopep8 alongside a linter on commit. There should be an easy way to bypass the autopep8 in case it improves readability. Perhaps applying autopep8 with a commit hook is too aggressive and we can choose to apply it to the master branch infrequently.

